### PR TITLE
ci: give release-please issues-write permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     outputs:
       release_created: "${{ steps.release-please.outputs.release_created }}"


### PR DESCRIPTION
This is needed so that it can create labels if they don't exist yet.