### PR TITLE
ci: run CI pipeline on undrafting a PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,12 @@
 name: CI
 
 on:
-  pull_request: {}
+  pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
 
 jobs:
   test:


### PR DESCRIPTION
This is needed for the release-please workflow.